### PR TITLE
Fix boot loop, battery reset, timer leak, and flash write crash on Pico 2W

### DIFF
--- a/MicroPython/modules/picocalc.py
+++ b/MicroPython/modules/picocalc.py
@@ -81,7 +81,11 @@ class PicoKeyboard:
         self.ignor = True
         self.address = address
         self.temp=bytearray(2)
-        self.reset()
+        # Do NOT send the reset command (_REG_RST) to the keyboard MCU on
+        # cold/battery boot. The keyboard MCU is also a power-management
+        # controller; resetting it can briefly cut power to the Pico on
+        # battery, causing a hard-reset loop. The MCU is already in its
+        # default state on power-on, so reset is unnecessary here.
         self.isShift = False
         self.isCtrl = False
         self.isAlt = False

--- a/MicroPython/modules/vt.py
+++ b/MicroPython/modules/vt.py
@@ -86,8 +86,11 @@ class vt(uio.IOBase):
             except ValueError:
                 raise ValueError("Non-ASCII character in vtterminal.read()")
 
-        n = self.keyboard.readinto(self.keyboardInput)
-        if n:          
+        try:
+            n = self.keyboard.readinto(self.keyboardInput)
+        except OSError:
+            n = None
+        if n:
             keys = bytes(self.keyboardInput[:n])
             if self.screencaptureKey in keys:
                 self.screencapture()

--- a/MicroPython/picocalcdisplay/picocalcdisplay.c
+++ b/MicroPython/picocalcdisplay/picocalcdisplay.c
@@ -116,7 +116,11 @@ void setpixelLUT1(int32_t x, int32_t y,uint16_t color);
 
 
 void core1_main() {
-  //multicore_lockout_victim_init();
+  // Register Core 1 as a multicore-lockout victim. MicroPython's LittleFS
+  // driver calls multicore_lockout_start_blocking() before programming flash;
+  // without this, Core 0 programs flash while Core 1 executes XIP code,
+  // causing a hard fault / reset on any filesystem write.
+  multicore_lockout_victim_init();
   //static int frame = 0;
   while (1) {
     //if (++frame % 100 == 0) {

--- a/MicroPython/vtterminal/vtterminal.c
+++ b/MicroPython/vtterminal/vtterminal.c
@@ -1516,6 +1516,9 @@ static mp_obj_t vtterminal_init(mp_obj_t fb_obj){
     setCursorToHome();
 
     //init the timer and callback
+    // Cancel any existing timer before re-adding; soft reset calls
+    // vtterminal_init() again and without this we leak a timer slot each time.
+    cancel_repeating_timer(&cursor_timer);
     add_repeating_timer_ms(250, dispCursor, NULL, &cursor_timer);
     return mp_const_true;
 }


### PR DESCRIPTION
## Summary

These are four bugs I hit running this firmware on a Pico 2W. Each one is a targeted fix with no unrelated changes.

---

### 1. `vt.py` — Boot loop / blank display after boot

**Root cause:** The keyboard I2C bus returns `OSError: EIO` on the very first `readinto()` call after cold boot. This exception propagated out of `vt._updateInternalBuffer()`, which caused MicroPython to deactivate `dupterm` — killing the display REPL. The screen would briefly show the prompt then go dead, which looks like a boot loop.

**Fix:** Wrap `self.keyboard.readinto()` in `try/except OSError` and treat it as "no key pressed" rather than crashing.

---

### 2. `picocalc.py` — Hard-reset loop on battery power

**Root cause:** `PicoKeyboard.__init__()` calls `self.reset()`, which sends a reset command to the keyboard MCU. The keyboard MCU also acts as a power-management controller — resetting it on battery-powered boot can briefly cut power to the Pico, triggering a hard-reset loop. (USB-powered boot doesn't exhibit this because VBUS comes from USB, not the MCU circuit.)

**Fix:** Remove the `self.reset()` call. The MCU is already in its default state on power-on; the reset is unnecessary.

---

### 3. `vtterminal.c` — Hardware timer leak on soft reset

**Root cause:** `vtterminal_init()` calls `add_repeating_timer_ms()` without first canceling the existing cursor timer. Soft reset (`Ctrl-D`) calls `vtterminal_init()` again, leaking one timer slot each time. The RP2040/RP2350 has a limited number of alarm slots; exhausting them causes a panic.

**Fix:** Call `cancel_repeating_timer(&cursor_timer)` before `add_repeating_timer_ms()`.

---

### 4. `picocalcdisplay.c` — Hard fault on any filesystem write

**Root cause:** `multicore_lockout_victim_init()` in `core1_main()` was commented out. MicroPython's LittleFS driver calls `multicore_lockout_start_blocking()` before programming flash — but only waits for Core 1 if it has registered as a lockout victim. Without this registration, any filesystem write (saving a file, etc.) causes Core 0 to program flash while Core 1 executes XIP code, resulting in a hard fault and reset.

**Fix:** Uncomment `multicore_lockout_victim_init()` and add an explanatory comment.

---

Tested on Raspberry Pi Pico 2W. Happy to answer any questions.